### PR TITLE
Just rid of the line causing language issues

### DIFF
--- a/UI/ui_functions.lua
+++ b/UI/ui_functions.lua
@@ -4,7 +4,7 @@ local nativefs = require("nativefs")
 G.FUNCS.apply_settings = function(e)
   S.SETTINGS = deepcopy(S.TEMP_SETTINGS)
   S:write_settings('settings')
-  G:set_language()
+  --G:set_language()
 end
 
 G.FUNCS.saturn_features_button = function(e)


### PR DESCRIPTION
As I've mentioned before, this line is causing compatibility issues with Steamodded (and likely other mods). Specifically, it causes some of the lines in Steamodded to be rendered as "ERROR". 